### PR TITLE
Added Hammerspoon with AppleScript in init.lua to auto-start connections when Royal TSX is launched

### DIFF
--- a/Automation/AppleScript/Hammerspoon/init.lua
+++ b/Automation/AppleScript/Hammerspoon/init.lua
@@ -1,0 +1,30 @@
+function applicationWatcher(appName, eventType, appObject)
+    if (eventType == hs.application.watcher.launched) then
+        if (appName == "Royal TSX") then
+            local applescriptCode = [[
+                tell application "Royal TSX"
+                    -- Replace 'Terminal' with the name of the connection you want to open
+                    set targetName to "Terminal"
+                    
+                    -- Get the ID of the connection whose name matches the target name
+                    set conIds to id of every connection whose name is equal to targetName
+                    
+                    -- If there's a matching ID, connect
+                    if (count of conIds) > 0 then
+                        set conId to item 1 of conIds
+                        connect conId
+                    else
+                        display dialog "No connection found with the name: " & targetName
+                    end if
+                end tell
+            ]]
+            local ok, result = hs.osascript.applescript(applescriptCode)
+            if not ok then
+                hs.notify.show("AppleScript Error", "Failed to run the script", result)
+            end
+        end
+    end
+end
+
+appWatcher = hs.application.watcher.new(applicationWatcher)
+appWatcher:start()


### PR DESCRIPTION
Added an automation feature utilizing Hammerspoon to automatically start a connection when Royal TSX is launched. The `init.lua` file includes an AppleScript that will launch a connection based on the connection name. Users simply need to install Hammerspoon, add the provided `init.lua` config, reload, and the specified connection in the script will auto-start upon launching Royal TSX. By default, the script auto-starts the connection named "Terminal", but users can easily edit the connection name in the `init.lua` file as needed. The `init.lua` file contains comments with instructions to guide users.