### PR TITLE
Update `create-pull-request` action

### DIFF
--- a/.github/workflows/dynamic_folder_index.yml
+++ b/.github/workflows/dynamic_folder_index.yml
@@ -33,7 +33,7 @@ jobs:
         run: dotnet run --project ./tools/ToolboxIndex -- "./Dynamic Folder"
       
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3.10.1
+        uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "[ci] Dynamic Folder Index updated"
           title: "[ci] Dynamic Folder Index updated"


### PR DESCRIPTION
The version currently used is quite outdated and could do well with an upgrade, 

e.g. ref https://github.com/peter-evans/create-pull-request/releases/tag/v4.2.4:
> ⚙️ Patches some recent security vulnerabilities.
