### PR TITLE
Enable `README.md` generation when re-indexing

### DIFF
--- a/.github/workflows/dynamic_folder_index.yml
+++ b/.github/workflows/dynamic_folder_index.yml
@@ -30,7 +30,7 @@ jobs:
           dotnet-version: '9.0.x'
 
       - name: Run Rebuild Index Tool
-        run: dotnet run --project ./tools/ToolboxIndex -- "./Dynamic Folder"
+        run: dotnet run --project ./tools/ToolboxIndex -- "./Dynamic Folder" --generate-readme-files
       
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Enable generating `README.md` files in folders containing `.rdfe`/`.rdfx` files when the CI job re-builds the dynamic folder index.

## What is the current behavior?

To understand what the various `.rdf*` files in this repo do, which dependencies they have, and how to configure them correctly, users must import them into TS/TSX and review the `Notes` there.

## What is the updated/expected behavior with this PR?

The HTML notes embedded into `.rdf*` files are converted to Markdown and a `README.md` file is automatically generated in each folder containing such files, whenever the CI re-indexing job runs. This opens up the embedded usage instructions for all users to access in the GitHub online interface.

## How was the solution implemented (if it's not obvious)?

The generator tool option is enabled here, but to actually generate the README files, a manual run of the CI job will be required after this PR lands.

## Checklist
- [x] Does not include or update generated files.
   <!--- 
   Avoid editing any `.autogen.*` and `README.md` files manually. 
   
   Such changes from your fork will be lost once a pull request is accepted and merged. A repo tool runs at that point, re-generating all these files and overwriting your changes.

   See  https://github.com/royalapplications/toolbox/blob/master/CONTRIBUTING.md#do-not-include-or-update-generated-files  for details
   -->