### PR TITLE
Enable script file extraction when re-indexing

### DIFF
--- a/.github/workflows/dynamic_folder_index.yml
+++ b/.github/workflows/dynamic_folder_index.yml
@@ -30,7 +30,7 @@ jobs:
           dotnet-version: '9.0.x'
 
       - name: Run Rebuild Index Tool
-        run: dotnet run --project ./tools/ToolboxIndex -- "./Dynamic Folder" --generate-readme-files
+        run: dotnet run --project ./tools/ToolboxIndex -- "./Dynamic Folder" --generate-readme-files --extract-script-files
       
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
## What does the pull request do?

Enable extracting `Script` and `DynamicCredentialScript` contents from `.rdfe`/`.rdfx` files into standalone files in this repo when the CI job re-builds the dynamic folder index.

## What is the current behavior?

To review and understand the code embedded into `.rdf*` files in this repo, users must import them into TS/TSX and review the `Script` and `DynamicCredentialScript` there.

## What is the updated/expected behavior with this PR?

The `Script` and `DynamicScriptCredential` entries are extracted to standalone files, placed next to each source file. 
For instance, given an `Example.rdf*` this would create:

- `Example.script.autogen.EXT` for the `Script` content

- `Example.dyncred-script.autogen.EXT` for the `DynamicCredentialScript`
  content (if present)

(`.EXT` stands for the appropriate file extension for each script interpreter, e.g. `.py` for Python scripts or `.ps1` for PowerShell scripts.)

The `.autogen` name suffix and a header comment inserted at the top of each file remind that these are generated and should not be manually edited.

Extracting the embedded code into their own files enables GitHub features such as syntax highlighting or go-to-definition for many scripting languages.

## How was the solution implemented (if it's not obvious)?

The generator tool option is enabled here, but to actually extract the script files, a manual run of the CI job will be required after this PR lands.

## Checklist
- [x] Does not include or update generated files.
